### PR TITLE
Implements the "source-like" lib load function for python

### DIFF
--- a/src/dsc_io.py
+++ b/src/dsc_io.py
@@ -273,6 +273,7 @@ def csv_to_html(infile, outfile):
 def source_dirs(dirs):
     import sys, os, glob
     reserved = ['__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__spec__']
+    functions = list()
     for item in dirs:
         item = os.path.abspath(os.path.expanduser(item))
         sys.path.append(item)
@@ -280,7 +281,8 @@ def source_dirs(dirs):
             m = __import__(os.path.basename(module)[:-3])
             for i in dir(m):
                 if not i in reserved:
-                    globals()[i] = getattr(m,i)
+                    functions.append((i, getattr(m,i)))
+    return functions
 
 def main():
     import os, sys, pickle

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -541,8 +541,11 @@ class PyPlug(BasePlug):
         return res
 
     def get_input(self, params, lib, seed_option):
-        res = '__source_dirs__([{}])\n'.format(','.join(
+        # import from lib_path
+        res = 'functions = __source_dirs__([{}])\n'.format(','.join(
             [repr(x) for x in lib])) if len(lib) else ''
+        res += 'for name, func in functions:\n'
+        res += '    globals()[name] = func'
         # load parameters
         keys = [x for x in params if not x in self.container_vars]
         res += '\n' + '\n'.join(self.container)


### PR DESCRIPTION
The sys.modules dict does not seem to carry over from __source_dir__ to the aggregated python file. Therefore, I decided to pass over the name and target objects and make them global under the main file.